### PR TITLE
Elytra Curios Support and small fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -180,6 +180,11 @@
       "required": true
     },
     {
+      "projectID": 308989,
+      "fileID": 3522094,
+      "required": true
+    },
+    {
       "projectID": 298187,
       "fileID": 3498508,
       "required": true
@@ -330,8 +335,8 @@
       "required": true
     },
     {
-      "projectID": 231275,
-      "fileID": 3222705,
+      "projectID": 60089,
+      "fileID": 3202662,
       "required": true
     },
     {
@@ -340,8 +345,8 @@
       "required": true
     },
     {
-      "projectID": 60089,
-      "fileID": 3202662,
+      "projectID": 231275,
+      "fileID": 3222705,
       "required": true
     },
     {
@@ -372,6 +377,11 @@
     {
       "projectID": 283644,
       "fileID": 3750838,
+      "required": true
+    },
+    {
+      "projectID": 317716,
+      "fileID": 3522097,
       "required": true
     },
     {

--- a/modlist.html
+++ b/modlist.html
@@ -32,6 +32,7 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/mutil">mutil (by mickelus)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/apotheosis">Apotheosis (by Shadows_of_Fire)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/patchouli">Patchouli (by Vazkii)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/caelus">Caelus API (Forge) (by TheIllusiveC4)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/building-gadgets">Building Gadgets (by Direwolf20)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/more-minecarts">More Minecarts and Rails (by goldey3)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/pneumaticcraft-repressurized">PneumaticCraft: Repressurized (by desht_08)</a></li>
@@ -62,14 +63,15 @@
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/immersiveposts">Immersive Posts (by TwistedGate)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/fastworkbench">FastWorkbench (by Shadows_of_Fire)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2">Applied Energistics 2 (by AlgorithmX2)</a></li>
-<li><a href="https://www.curseforge.com/minecraft/mc-mods/ding">Ding (by ohaiiChun)</a></li>
-<li><a href="https://www.curseforge.com/minecraft/mc-mods/flywheel">Flywheel (by jozufozu)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/mouse-tweaks">Mouse Tweaks (by YaLTeR)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/flywheel">Flywheel (by jozufozu)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/ding">Ding (by ohaiiChun)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/item-filters">Item Filters (by LatvianModder)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/controlling">Controlling (by Jaredlll08)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/caves-and-cliffs-backport">Caves & Cliffs Backport (by blackgear27)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/hwyla">Hwyla (by TehNut)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/selene">Moonlight Lib (by MehVahdJukaar)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/placebo">Placebo (by Shadows_of_Fire)</a></li>
+<li><a href="https://www.curseforge.com/minecraft/mc-mods/elytra-slot">Elytra Slot (Forge) (by TheIllusiveC4)</a></li>
 <li><a href="https://www.curseforge.com/minecraft/mc-mods/eidolon">Eidolon (by elucent_)</a></li>
 </ul>

--- a/overrides/config/apotheosis/spawner.cfg
+++ b/overrides/config/apotheosis/spawner.cfg
@@ -5,7 +5,7 @@ general {
     I:"Spawner Silk Damage"=100
 
     # The level of silk touch needed to harvest a spawner.  Set to -1 to disable, 0 to always drop.  The enchantment module can increase the max level of silk touch. [range: -1 ~ 127, default: 1]
-    I:"Spawner Silk Level"=-1
+    I:"Spawner Silk Level"=1
 }
 
 

--- a/overrides/config/quark-common.toml
+++ b/overrides/config/quark-common.toml
@@ -426,7 +426,7 @@
 		#Can Rotten Flesh and Poisonous Potatoes be composted?
 		"Compostable Toxins" = true
 		#Can bones be smelted down to bone meal?
-		"Bone Meal Utility" = true
+		"Bone Meal Utility" = false
 		#Can any wool color be dyed?
 		"Dye Any Wool" = true
 		#Can Coral be crafted into dye?


### PR DESCRIPTION
-Added a mod that makes the Elytra compatible with the Curios back slot.
-Disabled bone smelting in Quark config because of Eidolon conflict.
-Set Apotheosis silk touch level required to harvest spawner back to 1.